### PR TITLE
OneOf validation rule location suggestions

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -42,7 +42,8 @@ type Query {
 }
 
 type Mutation {
-  addPet(pet: PetInput): Pet
+  addPet(pet: PetInput!): Pet
+  addPets(pet: [PetInput!]!): [Pet]
 }
 
 enum DogCommand {
@@ -1351,6 +1352,12 @@ query goodComplexDefaultValue($search: FindDogInput = { name: "Fido" }) {
     name
   }
 }
+
+mutation addPet($pet: PetInput! = { cat: { name: "Brontie" } }) {
+  addPet(pet: $pet) {
+    name
+  }
+}
 ```
 
 Non-coercible values (such as a String into an Int) are invalid. The following
@@ -1363,6 +1370,24 @@ fragment stringIntoInt on Arguments {
 
 query badComplexValue {
   findDog(searchBy: { name: 123 }) {
+    name
+  }
+}
+
+mutation oneOfWithNoFields {
+  addPet(pet: {}) {
+    name
+  }
+}
+
+mutation oneOfWithTwoFields($dog: DogInput) {
+  addPet(pet: { cat: { name: "Brontie" }, dog: $dog }) {
+    name
+  }
+}
+
+mutation listOfOneOfWithNullableVariable($dog: DogInput) {
+  addPets(pets: [{ dog: $dog }]) {
     name
   }
 }

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1906,11 +1906,11 @@ IsVariableUsageAllowed(variableDefinition, variableUsage):
 
 IsNonNullPosition(locationType, variableUsage):
 
-- Let {isOneOfField} be {true} if {variableUsage} is located within an
-  {ObjectField} entry and the parent type of {ObjectField} is a OneOf Input
-  Object; otherwise {false}.
-- If {isOneOfField} is {true} or {locationType} is a non-null type, return
-  {true}.
+- If {locationType} is a non-null type, return {true}.
+- If the location of {variableUsage} is an {ObjectField}:
+  - Let {parentLocationType} be the expected type of {ObjectField}'s parent
+    {ObjectValue}.
+  - If {parentLocationType} is a OneOf Input Object type, return {true}.
 - Return {false}.
 
 AreTypesCompatible(variableType, locationType):

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -2004,7 +2004,12 @@ Similarly a `[T]` cannot be passed to a `[T!]`.
 Variables used for OneOf Input Object fields must be non-nullable.
 
 ```graphql example
-mutation addPet($cat: CatInput!) {
+mutation addCat($cat: CatInput!) {
+  addPet(pet: { cat: $cat }) {
+    name
+  }
+}
+mutation addCatWithDefault($cat: CatInput! = { name: "Brontie" }) {
   addPet(pet: { cat: $cat }) {
     name
   }
@@ -2012,17 +2017,12 @@ mutation addPet($cat: CatInput!) {
 ```
 
 ```graphql counter-example
-mutation addPet($cat: CatInput) {
+mutation addNullableCat($cat: CatInput) {
   addPet(pet: { cat: $cat }) {
     name
   }
 }
-```
-
-Variables used for OneOf Input Object fields cannot have default values.
-
-```graphql counter-example
-mutation addPet($cat: CatInput = { name: "Kitty" }) {
+mutation addNullableCatWithDefault($cat: CatInput = { name: "Brontie" }) {
   addPet(pet: { cat: $cat }) {
     name
   }


### PR DESCRIPTION
## Existing "Values of Correct Type" covers most OneOf specifics

We don't need a specific rule to validate that the values for OneOf Input Objects coerce properly => That is covered by the "Values of Correct Type" Rule which states that

https://spec.graphql.org/draft/#sel-HALXDDDBCAAEDDDBlkc

- For each input Value value in the document:
  - Let type be the type expected in the position value is found.
  - value must be coercible to type. 

Because the OneOf PR has detailed coercion rules for OneOf, everything should be covered there, and the new rule does not seem necessary.

## Allowed Variable Positions are Changed with the Introduction of OneOf

We do need to update the positions within which variables are allowed, because non-null variables are not allowed in OneOf Input Object field positions. [For simplicity, this PR retains the same problems for variables with defaults that are fixed by [Strict All Variable Usages Are Allowed](https://github.com/graphql/graphql-spec/pull/1059)]. This is by design to better demonstrate that this is where these rule updates belong, and could be changed as desired.